### PR TITLE
transport: use golang.org/x/net/context/ctxhttp package

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/shurcooL/go/ctxhttp"
+	"golang.org/x/net/context/ctxhttp"
 )
 
 // Transport is an interface that can be implemented to replace the


### PR DESCRIPTION
The issue golang/go#21358 has been resolved upstream, so there's no more need to use a temporary fork of the `ctxhttp` package.

Also, [`github.com/shurcooL/go/ctxhttp`](https://godoc.org/github.com/shurcooL/go/ctxhttp) has been deprecated and will be deleted on 2018-12-01, see shurcooL/go@58262d155ee0c659f3e3963bfccbac0f6a6a1d2b.

(This is effectively a backport of https://github.com/shurcooL/graphql/commit/16b88644589aaa174a21ae55cac72a9f60d5d837.)

/cc @warpfork